### PR TITLE
Check for duplicate job ID and skip submission

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -745,8 +745,11 @@ static bool submit_upstream_work(CURL *curl, struct work *work)
     int i;
     bool rc = false;
 
+    static char* last_job_id = NULL;
+
     /* pass if the previous hash is not the current previous hash */
-    if (!submit_old && memcmp(work->data + 1, g_work.data + 1, 32))
+    if ((!submit_old && memcmp(work->data + 1, g_work.data + 1, 32))
+    || last_job_id && strcmp(work->job_id, last_job_id) == 0)
     {
         if (opt_debug)
         {
@@ -782,6 +785,8 @@ static bool submit_upstream_work(CURL *curl, struct work *work)
             applog(LOG_ERR, "submit_upstream_work stratum_send_line failed");
             goto out;
         }
+
+        last_job_id = strdup(work->job_id);
     }
     else if (work->txs)
     {


### PR DESCRIPTION
This fixes a bug when using P2Pool. The miner will submit multiple shares for the same job ID, causing P2Pool to disconnect the miner. This patch checks the job ID is not the same as the previous submitted share before sending it.

Example log from P2Pool:
```
2021-01-25 20:31:59.316369 GOT SHARE! x ce6d8847 prev 8b34ade1 age 1.04s DEAD ON ARRIVAL
2021-01-25 20:31:59.740538 > Couldn't link returned work's job id with its handler. This should only happen if this process was recently restarted!
2021-01-25 20:32:00.266804 GOT SHARE! x 14dfcebd prev 54917fa3 age 1.00s
2021-01-25 20:32:00.299138 New work for worker! Difficulty: 0.000373 Share difficulty: 0.000029 Total block value: 50.000000 VTCTEST including 0 transactions
2021-01-25 20:32:00.302606 GOT SHARE! x 3a5eb82b prev 54917fa3 age 1.03s DEAD ON ARRIVAL
2021-01-25 20:32:00.762343 > Couldn't link returned work's job id with its handler. This should only happen if this process was recently restarted!
2021-01-25 20:32:01.260784 GOT SHARE! x 47ddc40e prev 14dfcebd age 0.96s
2021-01-25 20:32:01.296185 GOT SHARE! x 56b4f7bc prev 14dfcebd age 1.00s DEAD ON ARRIVAL
```

From VerthashMiner:
```
[2021-01-25 20:47:05] INFO  Stratum requested work restart
[2021-01-25 20:47:05] DEBUG < {"error": null, "jsonrpc": "2.0", "id": 4, "result": true}
[2021-01-25 20:47:05] INFO  accepted: 72/213 (33.80%), total hashrate: 261.51 kH/s
[2021-01-25 20:47:05] DEBUG < {"error": null, "jsonrpc": "2.0", "id": 4, "result": false}
[2021-01-25 20:47:05] INFO  accepted: 72/214 (33.64%), total hashrate: 261.51 kH/s
[2021-01-25 20:47:06] DEBUG > {"method": "mining.submit", "params": ["x", "234133117309234079852855848534670839610", "01000000", "600f748a", "00003d84"], "id":4}
[2021-01-25 20:47:06] DEBUG > {"method": "mining.submit", "params": ["x", "234133117309234079852855848534670839610", "01000000", "600f748a", "00007400"], "id":4}
[2021-01-25 20:47:06] DEBUG > {"method": "mining.submit", "params": ["x", "234133117309234079852855848534670839610", "01000000", "600f748a", "0000e3e1"], "id":4}
```

I'm not sure if this is the right fix though, it seems like a hack. It does however solve the immediate problem. Let me know if you think there's a better solution than this.