### PR TITLE
Fix device options parsing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4100,7 +4100,7 @@ inline void cmd_result_update(cmd_result_t* cmdr, int argc, char *argv[])
                 sel.deviceMonitor = vh::defaultDeviceMonitor;
                 sel.gpuTemperatureLimit = vh::defaultGPUTemperatureLimit;
                 sel.occupancyPct = vh::defaultOccupancyPct;
-                while (0 != (token = strsep(&tokenBase, delims2)) && (paramIndex < 2))
+                while (0 != (token = strsep(&tokenBase, delims2)) && (paramIndex < 5))
                 {
                     if (paramIndex == 0)
                     {

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4040,7 +4040,7 @@ inline void cmd_result_update(cmd_result_t* cmdr, int argc, char *argv[])
                 sel.deviceMonitor = vh::defaultDeviceMonitor;
                 sel.gpuTemperatureLimit = vh::defaultGPUTemperatureLimit;
                 sel.occupancyPct = vh::defaultOccupancyPct;
-                while (0 != (token = strsep(&tokenBase, delims2)) && (paramIndex < 2))
+                while (0 != (token = strsep(&tokenBase, delims2)) && (paramIndex < 5))
                 {
                     if (paramIndex == 0)
                     {


### PR DESCRIPTION
The loop counter wasn't updated from 2 to 5 in the v0.7 release so only the 2 first options were actually being used